### PR TITLE
set target-cpu=native

### DIFF
--- a/labs/core_bound/vectorization_1/.cargo/config.toml
+++ b/labs/core_bound/vectorization_1/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "target-cpu=native"] # enable avx2

--- a/labs/core_bound/vectorization_2/.cargo/config.toml
+++ b/labs/core_bound/vectorization_2/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "target-cpu=native"] # enable avx2


### PR DESCRIPTION
AVX instructions are common on modern CPUs now, but rustc will only support sse/sse2 by default.

After adding this config file, I got  better performance by using AVX instructions on my laptop.