### PR TITLE
fix false_sharing_1: remove the use of Arc for accumulators

### DIFF
--- a/labs/memory_bound/false_sharing_1/src/lib.rs
+++ b/labs/memory_bound/false_sharing_1/src/lib.rs
@@ -4,22 +4,19 @@
 mod tests;
 
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::Arc;
 use std::thread;
 
 pub fn solution(data: &[u32], thread_count: usize) -> i32 {
     // Using std::atomic counters to disallow compiler to promote `target`
     // memory location into a register. This way we ensure that the store
     // to `target` stays inside the loop.
-    let mut accumulators: Vec<Arc<AtomicU32>> = Vec::with_capacity(thread_count);
-    for _ in 0..thread_count {
-        accumulators.push(Default::default());
-    }
+    let mut accumulators = Vec::with_capacity(thread_count);
+    accumulators.resize_with(thread_count, || AtomicU32::new(0));
     let chunks = data.chunks(data.len() / thread_count);
     thread::scope(|s| {
         // C++ uses `#pragma omp for` which splits into chunks, just like this
         for (idx, chunk) in chunks.enumerate() {
-            let target_acc = accumulators[idx % thread_count].clone();
+            let target_acc = &accumulators[idx % thread_count];
             s.spawn(move || {
                 for v in chunk {
                     // Perform computation on each input


### PR DESCRIPTION
The use of Arc in `Vec<Arc<AtomicU32>>` introduced one more level of indirection, and thus the `AtomicU32` items were not necessarily next to each other, which prevented false sharing.

With this patch 'perf c2c' shows a high number of Load Local HITM: 
```
=================================================
            Trace Event Information
=================================================
  Total records                     :    1118078
  Locked Load/Store Operations      :     542173
  Load Operations                   :     605111
  Loads - uncacheable               :        116
  Loads - IO                        :          0
  Loads - Miss                      :          6
  Loads - no mapping                :        420
  Load Fill Buffer Hit              :      20871
  Load L1D hit                      :      75878
  Load L2D hit                      :       1505
  Load LLC hit                      :     504054
  Load Local HITM                   :     468123
```