### PR TITLE
fix loop_interchange_1

### DIFF
--- a/labs/memory_bound/loop_interchange_1/README.md
+++ b/labs/memory_bound/loop_interchange_1/README.md
@@ -1,4 +1,1 @@
 This one is big and slow, so use release mode: `cargo test --release` and `cargo run --release`.
-
-The Rust version does not appear to be memory bound, but the C++ version is, running with the same Clang on the same machine. Can you help adjust the Rust version to better match the C++ version, including bottlenecks?
-

--- a/labs/memory_bound/loop_interchange_1/benches/bench_loop_interchange_1.rs
+++ b/labs/memory_bound/loop_interchange_1/benches/bench_loop_interchange_1.rs
@@ -1,11 +1,11 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
-use loop_interchange_1::{init, power, zero, N};
+use loop_interchange_1::{create_matrix, init, power, zero};
 
 fn bench1(c: &mut Criterion) {
-    let mut matrix_a = vec![vec![0.0f32; N]; N];
+    let mut matrix_a = create_matrix();
     init(&mut matrix_a);
-    let mut matrix_b = vec![vec![0.0f32; N]; N];
+    let mut matrix_b = create_matrix();
     zero(&mut matrix_b);
 
     c.bench_function("lab", |b| {

--- a/labs/memory_bound/loop_interchange_1/src/lib.rs
+++ b/labs/memory_bound/loop_interchange_1/src/lib.rs
@@ -12,8 +12,9 @@ pub const N: usize = 400;
 // unit test threads don't have, so we allocate it on the heap.
 pub type Matrix = Box<[[f32; N]; N]>;
 
+const ZERO_ARR: [[f32; N]; N] = [[0.0f32; N]; N];
 pub fn create_matrix() -> Matrix {
-    unsafe { Box::new_zeroed().assume_init() }
+    Box::new(ZERO_ARR)
 }
 
 // Make zero matrix
@@ -40,8 +41,8 @@ pub fn multiply(result: &mut Matrix, a: &Matrix, b: &Matrix) {
     zero(result);
 
     for i in 0..N {
-        for j in 0..N {
-            for k in 0..N {
+        for k in 0..N {
+            for j in 0..N {
                 result[i][j] += a[i][k] * b[k][j];
             }
         }

--- a/labs/memory_bound/loop_interchange_1/src/lib.rs
+++ b/labs/memory_bound/loop_interchange_1/src/lib.rs
@@ -41,8 +41,8 @@ pub fn multiply(result: &mut Matrix, a: &Matrix, b: &Matrix) {
     zero(result);
 
     for i in 0..N {
-        for k in 0..N {
-            for j in 0..N {
+        for j in 0..N {
+            for k in 0..N {
                 result[i][j] += a[i][k] * b[k][j];
             }
         }

--- a/labs/memory_bound/loop_interchange_1/src/lib.rs
+++ b/labs/memory_bound/loop_interchange_1/src/lib.rs
@@ -9,8 +9,12 @@ pub const N: usize = 400;
 // Square matrix 400 x 400
 // In the C++ original this is: std::array<std::array<float, N>, N>;
 // If we use [[f32; N]; N] fn `power` will need a 4 MB stack which
-// unit test threads don't have.
-pub type Matrix = Vec<Vec<f32>>;
+// unit test threads don't have, so we allocate it on the heap.
+pub type Matrix = Box<[[f32; N]; N]>;
+
+pub fn create_matrix() -> Matrix {
+    unsafe { Box::new_zeroed().assume_init() }
+}
 
 // Make zero matrix
 pub fn zero(result: &mut Matrix) {
@@ -47,12 +51,12 @@ pub fn multiply(result: &mut Matrix, a: &Matrix, b: &Matrix) {
 // Compute integer power of a given square matrix
 pub fn power(input: &Matrix, k: i32) -> Matrix {
     // Temporary products
-    let mut product_current = vec![vec![0.0f32; N]; N];
-    let mut product_next = vec![vec![0.0f32; N]; N];
+    let mut product_current = create_matrix();
+    let mut product_next = create_matrix();
 
     // Temporary elements = a^(2^integer)
     //let mut element_current = vec![[0.0f32; N]; N];
-    let mut element_next = vec![vec![0.0f32; N]; N];
+    let mut element_next = create_matrix();
 
     // Initial values
     identity(&mut product_current);

--- a/labs/memory_bound/loop_interchange_1/src/lib.rs
+++ b/labs/memory_bound/loop_interchange_1/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(new_uninit)]
-
 #[cfg(test)]
 mod tests;
 
@@ -12,8 +10,10 @@ pub const N: usize = 400;
 // unit test threads don't have, so we allocate it on the heap.
 pub type Matrix = Box<[[f32; N]; N]>;
 
-const ZERO_ARR: [[f32; N]; N] = [[0.0f32; N]; N];
 pub fn create_matrix() -> Matrix {
+    // in unoptimized builds this will copy from static memory
+    // in optimized builds it's just a memset
+    const ZERO_ARR: [[f32; N]; N] = [[0.0f32; N]; N];
     Box::new(ZERO_ARR)
 }
 

--- a/labs/memory_bound/loop_interchange_1/src/tests.rs
+++ b/labs/memory_bound/loop_interchange_1/src/tests.rs
@@ -1,14 +1,14 @@
-use crate::{identity, init, multiply, power, zero, Matrix, N};
+use crate::{create_matrix, identity, init, multiply, power, zero, Matrix, N};
 
 #[test]
 fn validate() {
     const K: i32 = 15;
     const K1: i32 = 5;
 
-    let mut a = vec![vec![0.0f32; N]; N];
-    let mut b = vec![vec![0.0f32; N]; N];
-    let mut c = vec![vec![0.0f32; N]; N];
-    let mut d = vec![vec![0.0f32; N]; N];
+    let mut a = create_matrix();
+    let mut b = create_matrix();
+    let mut c = create_matrix();
+    let mut d = create_matrix();
 
     init(&mut a);
     zero(&mut b);


### PR DESCRIPTION
fixed by using Box<[[f32; N]; N]> to make memory contiguous, now memory access pattern is in line with original lab without overflowing the stack. had to use a static to initialize matrices

also makes benchmark run about 4x faster (6m vs 1m30s on my machine)
