### PR TITLE
Fix build for latest compiler version.

### DIFF
--- a/labs/core_bound/dep_chains_1/src/init.rs
+++ b/labs/core_bound/dep_chains_1/src/init.rs
@@ -30,7 +30,7 @@ pub fn get_random_list(allocator: &Arena) -> *const List {
             },
             allocator,
         );
-        Box::into_raw(b)
+        Box::into_raw_with_allocator(b).0
     };
 
     let head = create_node(0);


### PR DESCRIPTION
Hi, for some reason `labs/core_bound/dep_chains_1/src/init.rs` line 33 gives the compiler error on v1.91.0-nightly:
```
expected Box<List>, found Box<List, &Arena>
```
I guess they renamed the function so that it is only present in the Box that doesn't have allocator API. Here is the [commit](https://github.com/rust-lang/rust/commit/15bd619d5f12b4d01bb645340e7eea97d7b0e7c7) from rust project.